### PR TITLE
Add config_file pillar to configure logstash

### DIFF
--- a/logstash/conf.sls
+++ b/logstash/conf.sls
@@ -1,1 +1,11 @@
-# Stub
+{%- set configfile = salt['pillar.get']('logstash:config_file') %}
+
+{% if configfile is defined %}
+/etc/logstash/conf.d/logstash.conf:
+  file.managed:
+    - source: {{ configfile  }}
+    - watch_in:
+      - service: logstash
+    - require_in:
+      - service: logstash
+{% endif %}


### PR DESCRIPTION
### Notes

This has no backward compatibility breaks.
### What

The Logstash Debian package has a directory it scans for config files, which is /etc/logstash/conf.d/*.conf. However, the formula for logstash provided only a way to configure logstash forwarder. This PR makes it possible to add your own custom configuration file.

Note: I've discussed this with @syphernl, and he told me it would probably be a better idea to serialise the configuration file from a pillar structure to ruby, so that it's easier to configure. Although I fully understand and support this idea, I don't think it's feasible right now. I will, however, attempt to support this later.
### How to test

Well, create a config file, and point logstash:config_file to it and see that logstash will use it.
